### PR TITLE
fix(release): add VS Code download + native rebuild to test-insiders job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,12 @@ jobs:
 
   # ── Test against VS Code Insiders before building any VSIX ──────────────────
   # Catches proposed-API regressions that only surface in Insiders.
-  # Runs on Linux only (fastest, no native-module rebuild needed for this check).
+  # Runs on Linux only (fastest).
   test-insiders:
     needs: verify-version
     runs-on: ubuntu-latest
+    env:
+      VSCODE_VERSION: insiders
     steps:
       - uses: actions/checkout@v6
 
@@ -55,8 +57,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Download VS Code Insiders
+        run: node -e "require('@vscode/test-electron').downloadAndUnzipVSCode('insiders')"
+
+      - name: Rebuild native modules for VS Code's Electron
+        run: npm run rebuild:native
+
       - name: Run integration tests against VS Code Insiders
-        run: xvfb-run -a npm run test:integration -- --vscode-version=insiders
+        run: xvfb-run -a npm run test:integration
 
   # ── Build one VSIX per platform on its matching OS ───────────────────────────
   build:


### PR DESCRIPTION
The test-insiders job was missing two critical steps:
1. Download VS Code Insiders before rebuilding (so rebuild-native.js can detect the correct Electron version from the installed binary)
2. Rebuild better-sqlite3 for VS Code Electron ABI

Without the rebuild, better-sqlite3 stays at NMV 115 (Node.js 20) but VS Code Insiders requires NMV 140 (Electron 39), causing 73 test failures.

Also fixed: the --vscode-version flag is not recognised by @vscode/test-cli (the correct flag is --code-version). The job-level VSCODE_VERSION=insiders env var is used instead, which .vscode-test.mjs already reads.